### PR TITLE
`drop_last = True` only for training data

### DIFF
--- a/deepobs/pytorch/datasets/dataset.py
+++ b/deepobs/pytorch/datasets/dataset.py
@@ -53,11 +53,11 @@ class DataSet(abc.ABC):
         self._train_eval_dataloader = self._make_train_eval_dataloader()
         self._test_dataloader = self._make_test_dataloader()
 
-    def _make_dataloader(self, dataset, sampler=None, shuffle=False):
+    def _make_dataloader(self, dataset, sampler=None, shuffle=False, drop_last=False):
         loader = dat.DataLoader(
             dataset,
             batch_size=self._batch_size,
-            drop_last=True,
+            drop_last=drop_last,
             pin_memory=self._pin_memory,
             num_workers=self._num_workers,
             sampler=sampler,
@@ -87,7 +87,9 @@ class DataSet(abc.ABC):
             train_dataset
         )
         # since random sampling, shuffle is useless
-        train_loader = self._make_dataloader(train_dataset, sampler=train_sampler)
+        train_loader = self._make_dataloader(
+            train_dataset, sampler=train_sampler, drop_last=True  # drop last!
+        )
         valid_loader = self._make_dataloader(valid_dataset, sampler=valid_sampler)
         return train_loader, valid_loader
 

--- a/deepobs/pytorch/datasets/quadratic.py
+++ b/deepobs/pytorch/datasets/quadratic.py
@@ -74,7 +74,9 @@ class quadratic(dataset.DataSet):
         Y = self._make_labels()
         valid_dataset = dat.TensorDataset(X, Y)
 
-        train_loader = self._make_dataloader(train_dataset, shuffle=True)
+        train_loader = self._make_dataloader(
+            train_dataset, shuffle=True, drop_last=True
+        )
         valid_loader = self._make_dataloader(valid_dataset)
         return train_loader, valid_loader
 

--- a/deepobs/pytorch/runners/runner.py
+++ b/deepobs/pytorch/runners/runner.py
@@ -107,22 +107,23 @@ class PTRunner(Runner):
         elif phase == "VALID":
             tproblem.valid_init_op()
             msg = "VALID:"
-        # evaluation loop over every batch of the corresponding evaluation set
+        
+        # Evaluation loop over every batch of the corresponding evaluation set
         loss = 0.0
         accuracy = 0.0
-        batchCount = 0.0
+        num_data = 0
         while True:
             try:
-                batch_loss, batch_accuracy = tproblem.get_batch_loss_and_accuracy()[:2]
-                batchCount += 1.0
-                loss += batch_loss.item()
-                accuracy += batch_accuracy
+                batch_loss, batch_acc, batch_size = tproblem.get_batch_loss_and_accuracy()
+                num_data += batch_size
+                loss += batch_size * batch_loss.item()
+                accuracy += batch_size * batch_acc
             except StopIteration:
                 break
 
-        if batchCount > 0:
-            loss /= batchCount
-            accuracy /= batchCount
+        if num_data > 0:
+            loss /= num_data
+            accuracy /= num_data
         else:
             return None, None  # empty data loader
 

--- a/deepobs/pytorch/runners/runner.py
+++ b/deepobs/pytorch/runners/runner.py
@@ -89,13 +89,15 @@ class PTRunner(Runner):
         Has to be called in the beggining of every epoch within the
         training method. Returns the losses and accuracies.
 
+        NOTE: This function assumes the loss-function to use the "mean" 
+        reduction.
+
         Args:
             tproblem (testproblem): The testproblem instance to evaluate
             phase (str): The phase of the evaluation. Must be one of 'TRAIN', 'VALID' or 'TEST'
         Returns:
             float: The loss of the current state.
             float: The accuracy of the current state.
-
         """
 
         if phase == "TEST":

--- a/deepobs/pytorch/runners/runner.py
+++ b/deepobs/pytorch/runners/runner.py
@@ -113,7 +113,7 @@ class PTRunner(Runner):
         batchCount = 0.0
         while True:
             try:
-                batch_loss, batch_accuracy = tproblem.get_batch_loss_and_accuracy()
+                batch_loss, batch_accuracy = tproblem.get_batch_loss_and_accuracy()[:2]
                 batchCount += 1.0
                 loss += batch_loss.item()
                 accuracy += batch_accuracy
@@ -236,7 +236,7 @@ class StandardRunner(PTRunner):
             while True:
                 try:
                     opt.zero_grad()
-                    batch_loss, _ = tproblem.get_batch_loss_and_accuracy()
+                    batch_loss = tproblem.get_batch_loss_and_accuracy()[0]
                     batch_loss.backward()
                     opt.step()
 
@@ -423,8 +423,7 @@ class LearningRateScheduleRunner(PTRunner):
             while True:
                 try:
                     opt.zero_grad()
-                    batch_loss, _ = tproblem.get_batch_loss_and_accuracy()
-
+                    batch_loss = tproblem.get_batch_loss_and_accuracy()[0]
                     batch_loss.backward()
                     opt.step()
 

--- a/deepobs/pytorch/testproblems/imagenet_resnet50.py
+++ b/deepobs/pytorch/testproblems/imagenet_resnet50.py
@@ -442,7 +442,7 @@ class imagenet_data(DataSet):
         """Create the training and validation data loader."""
 
         train_loader = self._make_dataloader(
-            self._train_data, sampler=self._train_sampler
+            self._train_data, sampler=self._train_sampler, drop_last=True
         )
         self._train_indices = list(range(len(self._train_data)))
 

--- a/deepobs/pytorch/testproblems/testproblem.py
+++ b/deepobs/pytorch/testproblems/testproblem.py
@@ -123,7 +123,7 @@ class TestProblem(abc.ABC):
 
         Returns:
             callable:  The function that calculates the loss/accuracy on the
-                current batch.
+                current batch. This function also returns the mini-batch size.
         """
         inputs, labels = self._get_next_batch()
         inputs = inputs.to(self._device)
@@ -153,7 +153,8 @@ class TestProblem(abc.ABC):
             else:
                 regularizer_loss = torch.tensor(0.0, device=torch.device(self._device))
 
-            return loss + regularizer_loss, accuracy
+            # Return mini-batch loss, accuracy and the mini-batch size
+            return loss + regularizer_loss, accuracy, total
 
         return forward_func
 
@@ -171,13 +172,14 @@ class TestProblem(abc.ABC):
 
         Returns:
             float/torch.tensor, float: loss and accuracy of the model on the
-                current batch.
+                current batch and mini-batch size.
         """
         forward_func = self.get_batch_loss_and_accuracy_func(
             reduction=reduction,
             add_regularization_if_available=add_regularization_if_available,
         )
 
+        # Return mini-batch loss, accuracy and the mini-batch size
         return forward_func()
 
     def get_regularization_loss(self):


### PR DESCRIPTION
**Issue:** So far, `DeepOBS` uses `drop_last = True` by default. This makes sense for the `train_loader` (because the optimizer may be affected negatively by a particularly small last mini-batch), but for the other data loaders it is not justified. 

**Solution:** This PR solves this by setting `drop_last` to `False` by default and only using `drop_last = True` for the training loader. Methods that use the data loaders now have to deal with potentially different mini-batch sizes, e.g. the `PTRunner`'s `evaluate` method. We fix this as well.